### PR TITLE
[이유진]Week4

### DIFF
--- a/Weekly-Mission/folder.html
+++ b/Weekly-Mission/folder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/Weekly-Mission/index.html
+++ b/Weekly-Mission/index.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
 <html lang="ko">
 
-<html>
-
 <head>
   <meta charset="utf-8" />
   <title>Linkbrary</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta property="og:title" content="Linkbrary" key="title" />
+  <meta property="og:title" content="Linkbrary"/>
   <meta name="description" property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" key="description" />
   <meta property="og:image" content="https://visitbusan.net/uploadImgs/files/cntnts/20211130150754165_wufrotr"
     key="image" />

--- a/Weekly-Mission/scripts/sign-in.js
+++ b/Weekly-Mission/scripts/sign-in.js
@@ -1,0 +1,18 @@
+document.getElementById('email').addEventListener('focusout', function() {
+  var emailInput = this.value.trim();
+  var errorElement = document.getElementById('email-error');
+
+  if (emailInput === '') {
+    if (!errorElement) {
+      errorElement = document.createElement('div');
+      errorElement.id = 'email-error';
+      errorElement.textContent = '이메일을 입력해 주세요.';
+      errorElement.style.color = 'red';
+      this.parentNode.insertBefore(errorElement, this.nextSibling);
+    }
+  } else {
+    if (errorElement) {
+      errorElement.parentNode.removeChild(errorElement);
+    }
+  }
+});

--- a/Weekly-Mission/scripts/sign-in.js
+++ b/Weekly-Mission/scripts/sign-in.js
@@ -1,4 +1,6 @@
-document.getElementById('email').addEventListener('focusout', function() {
+/* 이메일 input */
+
+document.getElementById('email').addEventListener('focusout', function () {
   var emailInput = this.value.trim();
   var errorElement = document.getElementById('email-error');
 
@@ -29,3 +31,44 @@ function isValidEmail(email) {
   var emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 }
+
+/* 로그인 기능 */
+
+document.getElementById('signin-form').addEventListener('submit', function (event) {
+  event.preventDefault();
+
+  var emailInput = document.getElementById('email').value.trim();
+  var passwordInput = document.getElementById('current-password').value.trim();
+
+  // 예시 이메일 비밀번호
+  var correctEmail = 'test@codeit.com';
+  var correctPassword = 'codeit101';
+
+  var emailErrorElement = document.getElementById('email-error');
+  var passwordErrorElement = document.getElementById('password-error');
+
+  if (emailInput === correctEmail && passwordInput === correctPassword) {
+    // 로그인이 성공한 경우
+    window.location.href = './folder.html';
+  } else {
+    // 로그인이 실패한 경우
+    if (emailInput !== correctEmail || emailErrorElement) {
+      emailErrorElement = document.createElement('div');
+      emailErrorElement.id = 'email-error';
+      emailErrorElement.textContent = '이메일을 확인해 주세요.';
+      emailErrorElement.style.color = 'red';
+      var emailInputElement = document.getElementById('email');
+      emailInputElement.parentNode.insertBefore(emailErrorElement, emailInputElement.nextSibling);
+      console.log("이메일 오류");
+    }
+    if (passwordInput !== correctPassword || passwordErrorElement) {
+      passwordErrorElement = document.createElement('div');
+      passwordErrorElement.id = 'email-error';
+      passwordErrorElement.textContent = '비밀번호를 확인해 주세요.';
+      passwordErrorElement.style.color = 'red';
+      var passwordInputElement = document.getElementById('current-password');
+      passwordInputElement.parentNode.insertBefore(passwordErrorElement, passwordInputElement.nextSibling);
+      console.log("비밀번호 오류");
+    }
+  }
+});

--- a/Weekly-Mission/scripts/sign-in.js
+++ b/Weekly-Mission/scripts/sign-in.js
@@ -32,6 +32,27 @@ function isValidEmail(email) {
   return emailRegex.test(email);
 }
 
+/* 비밀번호 input */
+
+document.getElementById('current-password').addEventListener('focusout', function () {
+  var passwordinput = this.value.trim();
+  var errorElement = document.getElementById('password-error');
+
+  if (passwordinput === '') {
+    if (!errorElement) {
+      errorElement = document.createElement('div');
+      errorElement.id = 'password-error';
+      errorElement.textContent = '비밀번호를 입력해 주세요.';
+      errorElement.style.color = 'red';
+      this.parentNode.insertBefore(errorElement, this.nextSibling);
+    }
+  } else {
+    if (errorElement) {
+      errorElement.parentNode.removeChild(errorElement);
+    }
+  }
+});
+
 /* 로그인 기능 */
 
 document.getElementById('signin-form').addEventListener('submit', function (event) {

--- a/Weekly-Mission/scripts/sign-in.js
+++ b/Weekly-Mission/scripts/sign-in.js
@@ -10,9 +10,22 @@ document.getElementById('email').addEventListener('focusout', function() {
       errorElement.style.color = 'red';
       this.parentNode.insertBefore(errorElement, this.nextSibling);
     }
+  } else if (!isValidEmail(emailInput)) {
+    if (!errorElement) {
+      errorElement = document.createElement('div');
+      errorElement.id = 'email-error';
+      errorElement.textContent = '올바른 이메일 주소가 아닙니다.';
+      errorElement.style.color = 'red';
+      this.parentNode.insertBefore(errorElement, this.nextSibling);
+    }
   } else {
     if (errorElement) {
       errorElement.parentNode.removeChild(errorElement);
     }
   }
 });
+
+function isValidEmail(email) {
+  var emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}

--- a/Weekly-Mission/signin.html
+++ b/Weekly-Mission/signin.html
@@ -12,8 +12,6 @@
   <link href='https://fonts.googleapis.com/css?family=Acme' rel='stylesheet'>
   <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
   <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
-
-
 </head>
 
 <body>
@@ -58,5 +56,5 @@
     }
   }
 </script>
-
+<script src="scripts/sign-in.js"></script>
 </html>

--- a/Weekly-Mission/signin.html
+++ b/Weekly-Mission/signin.html
@@ -21,11 +21,11 @@
       <p>회원이 아니신가요?</p>
       <a href="signup.html">회원 가입하기</a>
     </div>
-    <form>
+    <form id="signin-form">
       <label for="email">이메일</label>
       <input type="email" id="email" name="email">
-      <label for="password">비밀번호</label>
-      <input type="password" id="password" name="password">
+      <label for="current-password">비밀번호</label>
+      <input type="password" id="current-password" name="current-password">
       <span class="icon"><ion-icon name="eye-off" id="eyeicon"></ion-icon></span>
       <button type="submit">로그인</button>
     </form>


### PR DESCRIPTION
## 요구사항

### 기본


- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [ ] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?
- [x] 로그인 버튼 클릭 또는 Enter키 입력으로 로그인 되나요?


### 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

## 주요 변경사항

- [![Netlify Status](https://api.netlify.com/api/v1/badges/7acde628-93bc-497d-b701-4527dbf3d88a/deploy-status)](https://app.netlify.com/sites/5-weekly-mission/deploys) https://5-weekly-mission.netlify.app/
- sign in 페이지에 이벤트 함수를 적용하였습니다.


## 스크린샷
- 이메일을 입력해 주세요.
<img width="320" alt="image" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/109906670/365701e2-8906-4892-9e62-fdcfb07792e5">

- 비밀번호를 입력해 주세요.
<img width="320" alt="image" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/109906670/4dc9badb-826e-43fb-8a4d-4017bc1cfb7f">

- 이메일을 확인해 주세요.
<img width="320" alt="image" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/109906670/470ceeb1-9923-4bcb-9685-8beeba776a5a">

- 비밀번호를 확인해 주세요.
<img width="320" alt="image" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/109906670/46006cab-00ca-4759-85b0-3f67ce4699a2">


## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
